### PR TITLE
Change dev setup commands so that they work

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ You can find the credentials for pgadmin in the `docker-compose.dev.yml` file.
 
 If you are running e-Babylab for the first time, you will need to:
 
-1. Set up the database using `docker-compose exec -f docker-compose.dev.yml web python manage.py migrate`. 
-2. Expose new static files (e.g., JavaScript files) using `docker-compose exec -f docker-compose.dev.yml web python manage.py collectstatic`.
-3. Create a superuser (for logging into the admin interface) using `docker-compose exec -f docker-compose.dev.yml web python manage.py createsuperuser`.
+1. Set up the database using `docker-compose -f docker-compose.dev.yml exec web python manage.py migrate`. 
+2. Expose new static files (e.g., JavaScript files) using `docker-compose -f docker-compose.dev.yml exec web python manage.py collectstatic`.
+3. Create a superuser (for logging into the admin interface) using `docker-compose -f docker-compose.dev.yml exec web python manage.py createsuperuser`.
 
 Once everything is set up, Django admin can be accessed at `http://localhost:8080/admin/`.
 


### PR DESCRIPTION
Just tried to set the project up locally on Ubuntu 20.04. `docker-compose exec -f docker-compose.dev.yml ...` does not work and only displays the help text of the `docker-compose exec` command. This is because the `-f <docker-compose-file.yml>`-Flag belongs to the `docker-compose` command. For correct and working commands, please see proposed change.