### PR TITLE
Lock to python 3.9

### DIFF
--- a/ipl/Dockerfile
+++ b/ipl/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.9
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
The current set of dependencies does not compile successfully when using the base image `pythhon:3`, this is most likely because today it resolves to 3.11 while when this project was setup the latest version was python 3.9

While the best solution would be to update the packages to run on Python 3.11, I am only proposing a quick'n'diurty solution that sets the base image to python 3.9.


<details>

<summary>Error with python 3.10+</summary>

```
#8 20.40       INFO: compile options: '-I/usr/local/lib/python3.10/site-packages/numpy/core/include -Ibuild/src.linux-x86_64-3.10/numpy/distutils/include -I/usr/local/include/python3.10 -c'
#8 20.40       extra options: '-funroll-all-loops -msse -msse2 -msse3'
#8 20.40       INFO: g++: numexpr/interpreter.cpp
#8 20.40       INFO: g++: numexpr/module.cpp
#8 20.40       INFO: g++: numexpr/numexpr_object.cpp
#8 20.40       numexpr/interpreter.cpp: In function ‘PyObject* NumExpr_run(NumExprObject*, PyObject*, PyObject*)’:
#8 20.40       numexpr/interpreter.cpp:1272:59: error: ‘NPY_ARRAY_UPDATEIFCOPY’ was not declared in this scope; did you mean ‘NPY_ITER_UPDATEIFCOPY’?
#8 20.40        1272 |                                         NPY_ARRAY_ALIGNED|NPY_ARRAY_UPDATEIFCOPY);
#8 20.40             |                                                           ^~~~~~~~~~~~~~~~~~~~~~
#8 20.40             |                                                           NPY_ITER_UPDATEIFCOPY
#8 20.40       error: Command "g++ -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/lib/python3.10/site-packages/numpy/core/include -Ibuild/src.linux-x86_64-3.10/numpy/distutils/include -I/usr/local/include/python3.10 -c numexpr/interpreter.cpp -o build/temp.linux-x86_64-cpython-310/numexpr/interpreter.o -MMD -MF build/temp.linux-x86_64-cpython-310/numexpr/interpreter.o.d -funroll-all-loops -msse -msse2 -msse3" failed with exit status 1
#8 20.40       INFO:
#8 20.40       ########### EXT COMPILER OPTIMIZATION ###########
#8 20.40       INFO: Platform      :
#8 20.40         Architecture: x64
#8 20.40         Compiler    : gcc
#8 20.40       
#8 20.40       CPU baseline  :
#8 20.40         Requested   : 'min'
#8 20.40         Enabled     : SSE SSE2 SSE3
#8 20.40         Flags       : -msse -msse2 -msse3
#8 20.40         Extra checks: none
#8 20.40       
#8 20.40       CPU dispatch  :
#8 20.40         Requested   : 'max -xop -fma4'
#8 20.40         Enabled     : SSSE3 SSE41 POPCNT SSE42 AVX F16C FMA3 AVX2 AVX512F AVX512CD AVX512_KNL AVX512_KNM AVX512_SKX AVX512_CLX AVX512_CNL AVX512_ICL
#8 20.40         Generated   : none
#8 20.40       INFO: CCompilerOpt.cache_flush[857] : write cache to path -> /tmp/pip-install-rrxpx96g/numexpr_80e25a429e6948c8a0e830443ee7ef8d/build/temp.linux-x86_64-cpython-310/ccompiler_opt_cache_ext.py
#8 20.40       [end of output]
#8 20.40   
#8 20.40   note: This error originates from a subprocess, and is likely not a problem with pip.
#8 20.41 error: legacy-install-failure
#8 20.41 
#8 20.41 × Encountered error while trying to install package.
#8 20.41 ╰─> numexpr
#8 20.41 
```

</details>